### PR TITLE
Fix parsing of article ID

### DIFF
--- a/pymed/article.py
+++ b/pymed/article.py
@@ -47,7 +47,7 @@ class PubMedArticle(object):
                 self.__setattr__(field, kwargs.get(field, None))
 
     def _extractPubMedId(self: object, xml_element: TypeVar("Element")) -> str:
-        path = ".//ArticleId[@IdType='pubmed']"
+        path = "MedlineCitation/PMID"
         return getContent(element=xml_element, path=path)
 
     def _extractTitle(self: object, xml_element: TypeVar("Element")) -> str:


### PR DESCRIPTION
This fix avoids returning also the IDs of cited papers
(they are within the ReferenceList element of the XML).

Close #1

Note: this issue was tracked as 22 on the original repository (now archived)

An alternative XPath to be used:
path = ".//PubmedData/ArticleIdList/ArticleId[@IdType='pubmed']"
