### PR TITLE
2 fix incomplete abstract or title

### DIFF
--- a/pymed/api.py
+++ b/pymed/api.py
@@ -97,7 +97,7 @@ class PubMed(object):
 
         # Return the total number of results (without retrieving them)
         return total_results_count
-    
+
     def _exceededRateLimit(self) -> bool:
         """ Helper method to check if we've exceeded the rate limit.
 


### PR DESCRIPTION
In some cases the title and/or abstract obtained was incomplete
(issue https://github.com/gijswobben/pymed/issues/23).

This happens when the text contains html markup tags (`<b>,` `<i>`, `<sub>`, `<sup>,` ...).

Example: PMID 31689885

```
<ArticleTitle>Gamma Irradiated <i>Rhodiola sachalinensis</i> Extract Ameliorates [...]</ArticleTitle>
Before the fix the returned title was just: 'Gamma Irradiated '
<AbstractText>The effect of <i>Rhodiola sachalinensis</i> Boriss extract irradiated [...]</ArticleTitle>
Before the fix the returned abstract was just: 'The effect of '
```

Fastest solution found: cleanup of frequently used html markup tags like `<b>`, `<i>`, `<sub>`,` <sup>`.
It seems to fix most of the papers correctly, at least for the above-mentioned tags.
